### PR TITLE
Add shared quiver configuration helper for pipelines

### DIFF
--- a/sample_pipelines/config.py
+++ b/sample_pipelines/config.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from quiver_representations import Quiver
+
+
+@dataclass
+class QuiverConfig:
+    """Configuration for constructing a quiver."""
+
+    quiver_name: str
+    vertices: List[str]
+    arrows: List[Tuple[str, str, str]]
+
+
+def build_quiver(cfg: QuiverConfig) -> Quiver:
+    """Build a :class:`Quiver` instance from a :class:`QuiverConfig`."""
+
+    quiver = Quiver(cfg.quiver_name)
+    vertex_map: Dict[str, int] = {}
+
+    for vertex_label in cfg.vertices:
+        vertex_map[vertex_label] = quiver.add_vertex(vertex_label)
+
+    for src_label, dst_label, arrow_label in cfg.arrows:
+        quiver.add_arrow(vertex_map[src_label], vertex_map[dst_label], arrow_label)
+
+    return quiver

--- a/sample_pipelines/run_quiver_analysis.py
+++ b/sample_pipelines/run_quiver_analysis.py
@@ -19,12 +19,10 @@ import zipfile
 from pathlib import Path
 from datetime import datetime
 
-from quiver_representations import (
-    ComplexNumbers,
-    Quiver,
-)
+from quiver_representations import ComplexNumbers
 from quiver_representations.module import Module
 from quiver_representations.analysis.coverage_pipeline import process_coverage
+from sample_pipelines.config import QuiverConfig, build_quiver
 
 
 def get_p_plus_i_dim_with_mult(Q, F, np: dict, ni: dict):
@@ -71,16 +69,14 @@ def get_p_plus_i_dim_with_mult(Q, F, np: dict, ni: dict):
     return p_dim, PI.get_dimension_vector()
 
 
-def create_quiver():
-    """Create the quiver (hardcoded example)."""
-    Q = Quiver("A3")
-    v0 = Q.add_vertex("v0")
-    v1 = Q.add_vertex("v1")
-    v2 = Q.add_vertex("v2")
-    Q.add_arrow(v0, v1, "a0")
-    Q.add_arrow(v1, v2, "a1")
-
-    return Q
+DEFAULT_QUIVER_CONFIG = QuiverConfig(
+    quiver_name="A3",
+    vertices=["v0", "v1", "v2"],
+    arrows=[
+        ("v0", "v1", "a0"),
+        ("v1", "v2", "a1"),
+    ],
+)
 
 
 def create_archive_excluding_jobs(source_dir, archive_path):
@@ -365,7 +361,7 @@ def main():
     print()
 
     # Create quiver and field
-    Q = create_quiver()
+    Q = build_quiver(DEFAULT_QUIVER_CONFIG)
     F = ComplexNumbers()
 
     print(f"Quiver: {Q.name}")

--- a/sample_pipelines/run_quiver_analysis_dn.py
+++ b/sample_pipelines/run_quiver_analysis_dn.py
@@ -19,12 +19,10 @@ import zipfile
 from pathlib import Path
 from datetime import datetime
 
-from quiver_representations import (
-    ComplexNumbers,
-    Quiver,
-)
+from quiver_representations import ComplexNumbers
 from quiver_representations.module import Module
 from quiver_representations.analysis.coverage_pipeline_dn import process_coverage_dn
+from sample_pipelines.config import QuiverConfig, build_quiver
 
 
 def get_p_plus_i_dim_with_mult(Q, F, np: dict, ni: dict):
@@ -71,21 +69,15 @@ def get_p_plus_i_dim_with_mult(Q, F, np: dict, ni: dict):
     return p_dim, PI.get_dimension_vector()
 
 
-def create_quiver():
-    """Create the D_n quiver (hardcoded example - user should modify this)."""
-    # Example: D_4 quiver
-    Q = Quiver("D4")
-    v0 = Q.add_vertex("v0")
-    v1 = Q.add_vertex("v1")
-    v2 = Q.add_vertex("v2")
-    v3 = Q.add_vertex("v3")
-    # Spine: 0 -> 1
-    Q.add_arrow(v0, v1, "a01")
-    # Branch vertex is v1 (n-3 = 4-3 = 1)
-    # Leaves are v2 and v3
-    Q.add_arrow(v1, v2, "a12")  # up leaf -> branch
-    Q.add_arrow(v1, v3, "a13")  # down leaf -> branch
-    return Q
+DEFAULT_QUIVER_CONFIG = QuiverConfig(
+    quiver_name="D4",
+    vertices=["v0", "v1", "v2", "v3"],
+    arrows=[
+        ("v0", "v1", "a01"),
+        ("v1", "v2", "a12"),
+        ("v1", "v3", "a13"),
+    ],
+)
 
 
 def create_archive_excluding_jobs(source_dir, archive_path):
@@ -281,7 +273,7 @@ def main():
     print()
 
     # Create quiver and field
-    Q = create_quiver()
+    Q = build_quiver(DEFAULT_QUIVER_CONFIG)
     F = ComplexNumbers()
 
     print(f"Quiver: {Q.name}")


### PR DESCRIPTION
## Summary
- add a shared QuiverConfig dataclass and build_quiver helper for sample pipelines
- update the A3 and D4 pipeline scripts to use the shared configuration instead of local builders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f9267a10c833383268c05bf333b9f)