### PR TITLE
Add optional HALT_ON_FAIL for parallel job execution

### DIFF
--- a/quiver_representations/scripts/run_all_parallel.sh
+++ b/quiver_representations/scripts/run_all_parallel.sh
@@ -12,6 +12,12 @@ set -euo pipefail
 
 NUM_WORKERS=${NUM_WORKERS:-64}
 
+# Optional: halt all jobs if one fails (set HALT_ON_FAIL=1 to enable)
+HALT_OPT=""
+if [ "${HALT_ON_FAIL:-}" = "1" ]; then
+    HALT_OPT="--halt now,fail=1"
+fi
+
 # Build a stable list of jobs
 find jobs -type f -name 'rad.m2' -printf '%h\n' | sort -V > joblist.txt
 
@@ -23,7 +29,7 @@ fi
 echo "Found $(wc -l < joblist.txt) jobs, running with $NUM_WORKERS workers"
 
 # Run jobs in parallel
-parallel -j "$NUM_WORKERS" --joblog run.log --eta '
+parallel -j "$NUM_WORKERS" --joblog run.log --eta $HALT_OPT '
   dir={};
   echo "START dir=$dir pid=$$ t=$(date -Is)" | tee "$dir/parallel.meta"
 

--- a/quiver_representations/utils/run_all_parallel.sh
+++ b/quiver_representations/utils/run_all_parallel.sh
@@ -1,11 +1,17 @@
 # Use environment variables with defaults
 NUM_WORKERS=${NUM_WORKERS:-64}
 
+# Optional: halt all jobs if one fails (set HALT_ON_FAIL=1 to enable)
+HALT_OPT=""
+if [ "${HALT_ON_FAIL:-}" = "1" ]; then
+    HALT_OPT="--halt now,fail=1"
+fi
+
 # 0) Build a stable list once
 find jobs -type f -name 'rad.m2' -printf '%h\n' | sort -V > joblist.txt
 
 # 1) Run exactly those jobs (no in-run retries)
-parallel -j $NUM_WORKERS --joblog run.log --eta '
+parallel -j $NUM_WORKERS --joblog run.log --eta $HALT_OPT '
   dir={};
   echo "START dir=$dir pid=$$ t=$(date -Is)" | tee "$dir/parallel.meta"
 


### PR DESCRIPTION
When HALT_ON_FAIL=1 environment variable is set, GNU parallel will stop all jobs immediately when any job fails (--halt now,fail=1). Default behavior (no env var) is unchanged.