### PR TITLE
run_all_parallel.sh: optional per-job memory cap via MEM_MAX

### DIFF
--- a/quiver_representations/scripts/run_all_parallel.sh
+++ b/quiver_representations/scripts/run_all_parallel.sh
@@ -4,6 +4,11 @@
 # Environment variables:
 #   NUM_WORKERS - number of parallel jobs (default: 64)
 #   GC_INITIAL_HEAP_SIZE - Macaulay2 GC heap size (default: not set)
+#   MEM_MAX - optional per-job memory cap, e.g. "50G". When set, each M2 job runs inside a
+#             transient systemd user scope with MemoryMax=$MEM_MAX. Empty/unset = no cap
+#             (default; behaviour unchanged). Needs a usable systemd user manager:
+#             XDG_RUNTIME_DIR must point at the user runtime dir (enable linger for
+#             headless/detached use).
 #
 # This script expects to be run from a directory containing a 'jobs' subdirectory
 # with rad.m2 files.
@@ -17,6 +22,14 @@ HALT_OPT=""
 if [ "${HALT_ON_FAIL:-}" = "1" ]; then
     HALT_OPT="--halt now,fail=1"
 fi
+
+# Optional per-job memory cap (set MEM_MAX, e.g. MEM_MAX=50G). Exported so the per-job
+# shells parallel spawns inherit it. Empty = no wrapper, i.e. run M2 directly as before.
+CAP=""
+if [ -n "${MEM_MAX:-}" ]; then
+    CAP="systemd-run --scope --user -p MemoryMax=$MEM_MAX"
+fi
+export CAP
 
 # Build a stable list of jobs
 find jobs -type f -name 'rad.m2' -printf '%h\n' | sort -V > joblist.txt
@@ -33,7 +46,7 @@ parallel -j "$NUM_WORKERS" --joblog run.log --eta $HALT_OPT '
   dir={};
   echo "START dir=$dir pid=$$ t=$(date -Is)" | tee "$dir/parallel.meta"
 
-  bash -lc "cd \"$dir\"; M2 --script rad.m2" \
+  $CAP bash -lc "cd \"$dir\"; M2 --script rad.m2" \
     >"$dir/rad_out.txt" 2>"$dir/rad_err.txt"
   rc=$?
 


### PR DESCRIPTION
Adds an opt-in `MEM_MAX` env var (e.g. `MEM_MAX=50G`) to `quiver_representations/scripts/run_all_parallel.sh`. When set, each M2 RAD job runs inside a transient `systemd --user` scope with that MemoryMax, so one runaway job cannot exhaust host RAM and OOM-kill its siblings.

Unset/empty `MEM_MAX` = no wrapper, i.e. byte-for-byte the current behaviour (safe default). `CAP` is exported so the per-job shells `parallel` spawns inherit it. Requires a usable systemd user manager (`XDG_RUNTIME_DIR` set; enable linger for headless/detached runs).